### PR TITLE
[feat] #1 날씨, 주소 데이터 모델 추가

### DIFF
--- a/SajaWeather/SajaWeather/Data/Model/AirQuality.swift
+++ b/SajaWeather/SajaWeather/Data/Model/AirQuality.swift
@@ -1,0 +1,31 @@
+//
+//  AirQuality.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/6/25.
+//
+
+import Foundation
+
+enum AirQuality: Int, CaseIterable {
+  case good = 1
+  case fair = 2
+  case moderate = 3
+  case poor = 4
+  case veryPoor = 5
+  
+  var description: String {
+    switch self {
+    case .good:
+      return "좋음"
+    case .fair:
+      return "보통"
+    case .moderate:
+      return "나쁨"
+    case .poor:
+      return "매우 나쁨"
+    case .veryPoor:
+      return "최악"
+    }
+  }
+}

--- a/SajaWeather/SajaWeather/Data/Model/CurrentWeather.swift
+++ b/SajaWeather/SajaWeather/Data/Model/CurrentWeather.swift
@@ -1,0 +1,24 @@
+//
+//  CurrentWeather.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/6/25.
+//
+
+import Foundation
+
+struct CurrentWeather {
+  let address: Location
+  let temperature: Int // 소수점
+  let maxTemp: Int
+  let minTemp: Int
+  let feelsLikeTemp: Int
+  let description: String
+  let icon: Int // id
+  let hourlyForecast: [HourlyForecast]
+  let dailyForecast: [DailyForecast]
+  let humidity: Int
+  let airQuality: AirQuality
+  let sunrise: String
+  let sunset: String
+}

--- a/SajaWeather/SajaWeather/Data/Model/CurrentWeather.swift
+++ b/SajaWeather/SajaWeather/Data/Model/CurrentWeather.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct CurrentWeather {
   let address: Location
-  let temperature: Int // 소수점
+  let temperature: Int
   let maxTemp: Int
   let minTemp: Int
   let feelsLikeTemp: Int
@@ -18,6 +18,7 @@ struct CurrentWeather {
   let hourlyForecast: [HourlyForecast]
   let dailyForecast: [DailyForecast]
   let humidity: Int
+  let windSpeed: Int
   let airQuality: AirQuality
   let sunrise: String
   let sunset: String

--- a/SajaWeather/SajaWeather/Data/Model/DailyForecast.swift
+++ b/SajaWeather/SajaWeather/Data/Model/DailyForecast.swift
@@ -1,0 +1,15 @@
+//
+//  DailyForecast.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/6/25.
+//
+
+import Foundation
+
+struct DailyForecast {
+  let day: String
+  let icon: Int // id
+  let maxTemp: Int
+  let minTemp: Int
+}

--- a/SajaWeather/SajaWeather/Data/Model/DailyForecast.swift
+++ b/SajaWeather/SajaWeather/Data/Model/DailyForecast.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct DailyForecast {
   let day: String
+  let humidity: Int
   let icon: Int // id
   let maxTemp: Int
   let minTemp: Int

--- a/SajaWeather/SajaWeather/Data/Model/HourlyForecast.swift
+++ b/SajaWeather/SajaWeather/Data/Model/HourlyForecast.swift
@@ -1,0 +1,15 @@
+//
+//  HourlyForecast.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/6/25.
+//
+
+import Foundation
+
+struct HourlyForecast {
+  let hour: Int
+  let icon: Int // id
+  let temperature: Int
+  let humidity: Int
+}

--- a/SajaWeather/SajaWeather/Data/Model/Location.swift
+++ b/SajaWeather/SajaWeather/Data/Model/Location.swift
@@ -1,0 +1,15 @@
+//
+//  Location.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/6/25.
+//
+
+import Foundation
+import CoreLocation
+
+struct Location {
+  let fullAddress: String     // "서울특별시 종로구 사직동"
+  let displayAddress: String       // "사직동" 
+  let coordinate: CLLocationCoordinate2D
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #1

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
화면에 보여지는 뷰 용도의 모델 만들었습니다
- AirQuality: 미세먼지 등급에 대한 enum ([api 응답값](https://openweathermap.org/api/air-pollution)이 1-5까지 숫자) 
- CurrentWeather: 세부 날씨에서 보여지는 전체 데이터 모델
- DailyForecast: 세부 날씨의 일별 예보 섹션에 대한 데이터 모델
- HourlyForecast: 세부 날씨의 시간별 예보 섹션에 대한 데이터 모델
- Location: 주소와 좌표를 갖는 데이터모델

<br>


## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
- 아이콘의 경우 [id값](https://openweathermap.org/weather-conditions) 별로 파일을 저장해 사용하면 좋을 것 같아 Int로 만들었습니다
- 온도에 대해서는 double로 제공이 되는데 화면에서는 int로 보여지는것 같아 int로 만들었습니다
- 일몰, 일출 시간 데이터도 응답값은 Int지만 화면에 보이기 위해 시간으로 처리해서 string으로 넘겨주는 것이 좋을것 같아 string으로 만들었습니다
- 혹시나 빠뜨리거나 불편한 게 있다면 편하게 말해주세요! 

<br>
