### PR TITLE
[Feat] #17 weatherapi repository

### DIFF
--- a/SajaWeather/SajaWeather/Data/Model/CurrentWeather+.swift
+++ b/SajaWeather/SajaWeather/Data/Model/CurrentWeather+.swift
@@ -17,8 +17,9 @@ extension CurrentWeather {
     coordinate: CLLocationCoordinate2D // 현재 위치나 저장된 위치
   ) {
     self.address = Location(
+      title: currentWeather.name,
+      subtitle:currentWeather.name,
       fullAddress: currentWeather.name, // 임시
-      displayAddress: currentWeather.name, // 임시
       coordinate: coordinate
     )
     

--- a/SajaWeather/SajaWeather/Data/Model/Location.swift
+++ b/SajaWeather/SajaWeather/Data/Model/Location.swift
@@ -9,7 +9,8 @@ import Foundation
 import CoreLocation
 
 struct Location {
-  let fullAddress: String     // 나중에 MKLocalSearch로
-  let displayAddress: String       // 나중에 MKLocalSearch로
+  let title: String  // "사직동"
+  let subtitle: String  // "서울특별시 종로구"
+  let fullAddress: String  // "서울특별시 종로구 사직동"
   let coordinate: CLLocationCoordinate2D
 }

--- a/SajaWeather/SajaWeather/Data/Model/TemperatureUnit.swift
+++ b/SajaWeather/SajaWeather/Data/Model/TemperatureUnit.swift
@@ -1,0 +1,13 @@
+//
+//  TemperatureUnit.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/11/25.
+//
+
+import Foundation
+
+enum TemperatureUnit: String, CaseIterable {
+  case celsius = "metric"
+  case fahrenheit = "imperial"
+}

--- a/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
+++ b/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
@@ -10,16 +10,18 @@ import MapKit
 import RxSwift
 import CoreLocation
 
-// MARK: - LocationSearchServiceType Protocol
 protocol LocationSearchServiceType {
+  /// "사직동" 입력 -> [종로구 사직동, 동래구 사직동 ...] 자동완성 제안
   func searchCompleter(query: String) -> Observable<[Location]>
+  
+  /// "종로구 사직동" 선택 -> 정확한 주소 및 좌표 반환
   func searchDetail(completion: MKLocalSearchCompletion) -> Single<Location>
 }
 
-// MARK: - LocationSearchService Implementation
 final class LocationSearchService: NSObject, LocationSearchServiceType {
+  
   private let completer = MKLocalSearchCompleter()
-  private var currentObserver: AnyObserver<[Location]>?
+  private var searchObserver: AnyObserver<[Location]>?
   
   override init() {
     super.init()
@@ -33,34 +35,37 @@ final class LocationSearchService: NSObject, LocationSearchServiceType {
   
   // MARK: - 자동완성 검색
   func searchCompleter(query: String) -> Observable<[Location]> {
+    
     return Observable.create { [weak self] observer in
       guard let self = self else {
         observer.onCompleted()
         return Disposables.create()
       }
-            
+      
+      // 빈 검색어 체크 (공백 제거 후 비어있으면)
       if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         observer.onNext([])
         observer.onCompleted()
         return Disposables.create()
       }
       
-      // 현재 observer 저장
-      self.currentObserver = observer.asObserver()
+      // 현재 observer 저장 (나중에 결과 전달받음)
+      self.searchObserver = observer.asObserver()
       
       // 검색 시작
       self.completer.queryFragment = query
       
       return Disposables.create {
         self.completer.cancel()
-        self.currentObserver = nil
+        self.searchObserver = nil
       }
     }
-    .timeout(.seconds(10), scheduler: MainScheduler.instance)
+    .timeout(.seconds(5), scheduler: MainScheduler.instance)
   }
   
-  // MARK: - 선택된 completion의 상세 정보 검색
+  // MARK: - 선택된 위치에 대한 상세 정보 검색
   func searchDetail(completion: MKLocalSearchCompletion) -> Single<Location> {
+    
     return Single.create { observer in
       
       let request = MKLocalSearch.Request(completion: completion)
@@ -95,7 +100,9 @@ final class LocationSearchService: NSObject, LocationSearchServiceType {
 }
 
 // MARK: - MKLocalSearchCompleterDelegate
+
 extension LocationSearchService: MKLocalSearchCompleterDelegate {
+  // 자동완성 결과가 도착했을때 호출되는 메서드
   func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
     
     let locations = completer.results.map { completion in
@@ -107,19 +114,21 @@ extension LocationSearchService: MKLocalSearchCompleterDelegate {
       )
     }
     
-    currentObserver?.onNext(locations)
-    currentObserver?.onCompleted()
-    currentObserver = nil
+    searchObserver?.onNext(locations)
+    searchObserver?.onCompleted()
+    searchObserver = nil
   }
   
+  // 검색 중 에러가 발생했을때 호출되는 메서드
   func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
-    currentObserver?.onNext([])
-    currentObserver?.onCompleted()
-    currentObserver = nil
+    searchObserver?.onNext([])
+    searchObserver?.onCompleted()
+    searchObserver = nil
   }
 }
 
 // MARK: - LocationSearchError
+
 enum LocationSearchError: LocalizedError {
   case noResults
   case unknown

--- a/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
+++ b/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
@@ -1,0 +1,135 @@
+//
+//  LocationSearchService.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/11/25.
+//
+
+import Foundation
+import MapKit
+import RxSwift
+import CoreLocation
+
+// MARK: - LocationSearchServiceType Protocol
+protocol LocationSearchServiceType {
+  func searchCompleter(query: String) -> Observable<[Location]>
+  func searchDetail(completion: MKLocalSearchCompletion) -> Single<Location>
+}
+
+// MARK: - LocationSearchService Implementation
+final class LocationSearchService: NSObject, LocationSearchServiceType {
+  private let completer = MKLocalSearchCompleter()
+  private var currentObserver: AnyObserver<[Location]>?
+  
+  override init() {
+    super.init()
+    setupCompleter()
+  }
+  
+  private func setupCompleter() {
+    completer.delegate = self
+    completer.resultTypes = .address
+  }
+  
+  // MARK: - 자동완성 검색
+  func searchCompleter(query: String) -> Observable<[Location]> {
+    return Observable.create { [weak self] observer in
+      guard let self = self else {
+        observer.onCompleted()
+        return Disposables.create()
+      }
+            
+      if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        observer.onNext([])
+        observer.onCompleted()
+        return Disposables.create()
+      }
+      
+      // 현재 observer 저장
+      self.currentObserver = observer.asObserver()
+      
+      // 검색 시작
+      self.completer.queryFragment = query
+      
+      return Disposables.create {
+        self.completer.cancel()
+        self.currentObserver = nil
+      }
+    }
+    .timeout(.seconds(10), scheduler: MainScheduler.instance)
+  }
+  
+  // MARK: - 선택된 completion의 상세 정보 검색
+  func searchDetail(completion: MKLocalSearchCompletion) -> Single<Location> {
+    return Single.create { observer in
+      
+      let request = MKLocalSearch.Request(completion: completion)
+      let search = MKLocalSearch(request: request)
+      
+      search.start { response, error in
+        if let error = error {
+          observer(.failure(error))
+          return
+        }
+        
+        guard let mapItem = response?.mapItems.first else {
+          observer(.failure(LocationSearchError.noResults))
+          return
+        }
+        
+        let location = Location(
+          title: mapItem.name ?? completion.title,
+          subtitle: completion.subtitle,
+          fullAddress: mapItem.placemark.title ?? "\(completion.subtitle) \(completion.title)",
+          coordinate: mapItem.placemark.coordinate
+        )
+        
+        observer(.success(location))
+      }
+      
+      return Disposables.create {
+        search.cancel()
+      }
+    }
+  }
+}
+
+// MARK: - MKLocalSearchCompleterDelegate
+extension LocationSearchService: MKLocalSearchCompleterDelegate {
+  func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+    
+    let locations = completer.results.map { completion in
+      Location(
+        title: completion.title,
+        subtitle: completion.subtitle,
+        fullAddress: "\(completion.subtitle) \(completion.title)",
+        coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0)
+      )
+    }
+    
+    currentObserver?.onNext(locations)
+    currentObserver?.onCompleted()
+    currentObserver = nil
+  }
+  
+  func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
+    currentObserver?.onNext([])
+    currentObserver?.onCompleted()
+    currentObserver = nil
+  }
+}
+
+// MARK: - LocationSearchError
+enum LocationSearchError: LocalizedError {
+  case noResults
+  case unknown
+  
+  var errorDescription: String? {
+    switch self {
+    case .noResults:
+      return "검색 결과가 없습니다"
+    case .unknown:
+      return "검색 중 오류가 발생했습니다"
+    }
+  }
+}

--- a/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
+++ b/SajaWeather/SajaWeather/Data/Service/LocationSearchService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MapKit
+import RxCocoa
 import RxSwift
 import CoreLocation
 
@@ -29,57 +30,41 @@ final class LocationSearchService: NSObject, LocationSearchServiceType {
   }
   
   private func setupCompleter() {
-    completer.delegate = self
     completer.resultTypes = .address
   }
   
   // MARK: - 자동완성 검색
+  
   func searchCompleter(query: String) -> Observable<[Location]> {
     
-    return Observable.create { [weak self] observer in
-      guard let self = self else {
-        observer.onCompleted()
-        return Disposables.create()
-      }
-      
-      // 빈 검색어 체크 (공백 제거 후 비어있으면)
-      if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-        observer.onNext([])
-        observer.onCompleted()
-        return Disposables.create()
-      }
-      
-      // 현재 observer 저장 (나중에 결과 전달받음)
-      self.searchObserver = observer.asObserver()
-      
-      // 검색 시작
-      self.completer.queryFragment = query
-      
-      return Disposables.create {
-        self.completer.cancel()
-        self.searchObserver = nil
-      }
+    if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      return Observable.just([])
     }
+    
+    return completer.rx.query(query)
+      .map { completions in
+        completions.map { completion in
+          Location(
+            title: completion.title,
+            subtitle: completion.subtitle,
+            fullAddress: "\(completion.subtitle) \(completion.title)",
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0)
+          )
+        }
+      }
     .timeout(.seconds(5), scheduler: MainScheduler.instance)
+    .catch { error in
+      return Observable.just([])
+    }
   }
   
   // MARK: - 선택된 위치에 대한 상세 정보 검색
+  
   func searchDetail(completion: MKLocalSearchCompletion) -> Single<Location> {
-    
-    return Single.create { observer in
-      
-      let request = MKLocalSearch.Request(completion: completion)
-      let search = MKLocalSearch(request: request)
-      
-      search.start { response, error in
-        if let error = error {
-          observer(.failure(error))
-          return
-        }
-        
-        guard let mapItem = response?.mapItems.first else {
-          observer(.failure(LocationSearchError.noResults))
-          return
+    return completion.rx.localSearch()
+      .map { response in
+        guard let mapItem = response.mapItems.first else {
+          throw LocationSearchError.noResults
         }
         
         let location = Location(
@@ -88,42 +73,9 @@ final class LocationSearchService: NSObject, LocationSearchServiceType {
           fullAddress: mapItem.placemark.title ?? "\(completion.subtitle) \(completion.title)",
           coordinate: mapItem.placemark.coordinate
         )
-        
-        observer(.success(location))
+        return location
       }
-      
-      return Disposables.create {
-        search.cancel()
-      }
-    }
-  }
-}
-
-// MARK: - MKLocalSearchCompleterDelegate
-
-extension LocationSearchService: MKLocalSearchCompleterDelegate {
-  // 자동완성 결과가 도착했을때 호출되는 메서드
-  func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
-    
-    let locations = completer.results.map { completion in
-      Location(
-        title: completion.title,
-        subtitle: completion.subtitle,
-        fullAddress: "\(completion.subtitle) \(completion.title)",
-        coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0)
-      )
-    }
-    
-    searchObserver?.onNext(locations)
-    searchObserver?.onCompleted()
-    searchObserver = nil
-  }
-  
-  // 검색 중 에러가 발생했을때 호출되는 메서드
-  func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
-    searchObserver?.onNext([])
-    searchObserver?.onCompleted()
-    searchObserver = nil
+      .asSingle()
   }
 }
 
@@ -140,5 +92,70 @@ enum LocationSearchError: LocalizedError {
     case .unknown:
       return "검색 중 오류가 발생했습니다"
     }
+  }
+}
+
+extension Reactive where Base: MKLocalSearchCompleter {
+  var delegate: DelegateProxy<MKLocalSearchCompleter, MKLocalSearchCompleterDelegate> {
+    return RxLocalSearchCompleterDelegateProxy.proxy(for: base)
+  }
+
+  func setDelegate(_ delegate: MKLocalSearchCompleterDelegate) -> Disposable {
+    return RxLocalSearchCompleterDelegateProxy.installForwardDelegate(
+      delegate,
+      retainDelegate: false,
+      onProxyForObject: base
+    )
+  }
+
+  func query(_ query: String) -> Observable<[MKLocalSearchCompletion]> {
+    return delegate
+      .methodInvoked(#selector(MKLocalSearchCompleterDelegate.completerDidUpdateResults(_:)))
+      .compactMap { $0[0] as? MKLocalSearchCompleter }
+      .map(\.results)
+      .do(onSubscribe: { [base] in
+        base.queryFragment = query
+      }, onDispose: { [base] in
+        base.cancel()
+      })
+  }
+}
+
+extension Reactive where Base: MKLocalSearchCompletion {
+  func localSearch() -> Observable<MKLocalSearch.Response> {
+    return Observable.create { [base] observer in
+      let search = MKLocalSearch(request: MKLocalSearch.Request(completion: base))
+      search.start { response, error in
+        if let error = error {
+          observer.on(.error(error))
+        } else if let response = response {
+          observer.on(.next(response))
+          observer.on(.completed)
+        }
+      }
+      return Disposables.create {
+        search.cancel()
+      }
+    }
+  }
+}
+
+// 프록시 먼저 만들기
+final class RxLocalSearchCompleterDelegateProxy: DelegateProxy<MKLocalSearchCompleter, MKLocalSearchCompleterDelegate>, DelegateProxyType, MKLocalSearchCompleterDelegate {
+  static func registerKnownImplementations() {
+    register {
+      RxLocalSearchCompleterDelegateProxy(
+        parentObject: $0,
+        delegateProxy: RxLocalSearchCompleterDelegateProxy.self
+      )
+    }
+  }
+
+  static func currentDelegate(for object: MKLocalSearchCompleter) -> MKLocalSearchCompleterDelegate? {
+    return object.delegate
+  }
+
+  static func setCurrentDelegate(_ delegate: MKLocalSearchCompleterDelegate?, to object: MKLocalSearchCompleter) {
+    object.delegate = delegate
   }
 }

--- a/SajaWeather/SajaWeather/Data/Service/Network/WeatherAPI.swift
+++ b/SajaWeather/SajaWeather/Data/Service/Network/WeatherAPI.swift
@@ -9,9 +9,9 @@ import Foundation
 import Moya
 
 enum WeatherAPI {
-  case current(lat: Double, lon: Double)
-  case hourlyForecast(lat: Double, lon: Double)
-  case dailyForecast(lat: Double, lon: Double)
+  case current(lat: Double, lon: Double, units: TemperatureUnit)
+  case hourlyForecast(lat: Double, lon: Double, units: TemperatureUnit)
+  case dailyForecast(lat: Double, lon: Double, units: TemperatureUnit)
   case airQuality(lat: Double, lon: Double)
 }
 
@@ -39,38 +39,38 @@ extension WeatherAPI: TargetType {
   
   var task: Moya.Task {
     switch self {
-    case .current(let lat, let lon):
+    case .current(let lat, let lon, let units):
       return .requestParameters(
         parameters: [
           "lat": lat,
           "lon": lon,
           "appid": apiKey,
-          "units": "metric", // 섭씨로 받아옴
+          "units": units.rawValue,
           "lang": "kr"
         ],
         encoding: URLEncoding.queryString
       )
       
-    case .hourlyForecast(let lat, let lon):
+    case .hourlyForecast(let lat, let lon, let units):
       return .requestParameters(
         parameters: [
           "lat": lat,
           "lon": lon,
           "appid": apiKey,
-          "units": "metric",
+          "units": units.rawValue,
           "lang": "kr",
           "cnt": 24
         ],
         encoding: URLEncoding.queryString
       )
       
-    case .dailyForecast(let lat, let lon):
+    case .dailyForecast(let lat, let lon, let units):
       return .requestParameters(
         parameters: [
           "lat": lat,
           "lon": lon,
           "appid": apiKey,
-          "units": "metric",
+          "units": units.rawValue,
           "lang": "kr",
           "cnt": 10
         ],
@@ -90,7 +90,6 @@ extension WeatherAPI: TargetType {
   var headers: [String: String]? {
     return ["Content-Type": "application/json"]
   }
-  
   
   var sampleData: Data {
     switch self {

--- a/SajaWeather/SajaWeather/Data/Service/Network/WeatherService.swift
+++ b/SajaWeather/SajaWeather/Data/Service/Network/WeatherService.swift
@@ -12,7 +12,7 @@ import Moya
 import CoreLocation
 
 protocol WeatherServiceType {
-  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather>
+  func getCurrentWeather(coordinate: CLLocationCoordinate2D, units: TemperatureUnit) -> Single<CurrentWeather>
 }
 
 final class WeatherService: WeatherServiceType {
@@ -29,20 +29,20 @@ final class WeatherService: WeatherServiceType {
     )
   }
   
-  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather> {
+  func getCurrentWeather(coordinate: CLLocationCoordinate2D, units: TemperatureUnit) -> Single<CurrentWeather> {
     let lat = coordinate.latitude
     let lon = coordinate.longitude
     
     let currentWeatherObservable = provider.rx
-      .request(.current(lat: lat, lon: lon))
+      .request(.current(lat: lat, lon: lon, units: units))
       .map(CurrentWeatherResponseDTO.self)
     
     let hourlyForecastObservable = provider.rx
-      .request(.hourlyForecast(lat: lat, lon: lon))
+      .request(.hourlyForecast(lat: lat, lon: lon, units: units))
       .map(HourlyForecastResponseDTO.self)
     
     let dailyForecastObservable = provider.rx
-      .request(.dailyForecast(lat: lat, lon: lon))
+      .request(.dailyForecast(lat: lat, lon: lon, units: units))
       .map(DailyForecastResponseDTO.self)
     
     let airQualityObservable = provider.rx

--- a/SajaWeather/SajaWeather/Data/Service/Network/WeatherServiceStub.swift
+++ b/SajaWeather/SajaWeather/Data/Service/Network/WeatherServiceStub.swift
@@ -12,11 +12,11 @@ import RxMoya
 import Moya
 
 final class WeatherServiceStub: WeatherServiceType {
-  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather> {
+  func getCurrentWeather(coordinate: CLLocationCoordinate2D, units: TemperatureUnit) -> Single<CurrentWeather> {
     
     let stubProvider = MoyaProvider<WeatherAPI>(stubClosure: MoyaProvider.immediatelyStub)
     let weatherService = WeatherService(provider: stubProvider)
-    return weatherService.getCurrentWeather(coordinate: coordinate)
+    return weatherService.getCurrentWeather(coordinate: coordinate, units: units)
     
   }
 }

--- a/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
+++ b/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
@@ -9,13 +9,13 @@ import Foundation
 import RxSwift
 import CoreLocation
 
+typealias Coordinate = CLLocationCoordinate2D
+
 protocol WeatherRepositoryType {
-  var units: TemperatureUnit { get set }
-  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather>
+  func getCurrentWeather(coordinate: Coordinate, units: TemperatureUnit) -> Single<CurrentWeather>
 }
 
 final class WeatherRepository: WeatherRepositoryType {
-  var units: TemperatureUnit = .celsius
   
   private let weatherService: WeatherServiceType
   
@@ -23,7 +23,7 @@ final class WeatherRepository: WeatherRepositoryType {
     self.weatherService = weatherService
   }
   
-  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather> {
+  func getCurrentWeather(coordinate: Coordinate, units: TemperatureUnit) -> Single<CurrentWeather> {
     return weatherService.getCurrentWeather(coordinate: coordinate, units: units)
   }
 }

--- a/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
+++ b/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
@@ -12,6 +12,11 @@ import CoreLocation
 typealias Coordinate = CLLocationCoordinate2D
 
 protocol WeatherRepositoryType {
+  /// 특정 위치의 현재 날씨 정보를 가져옵니다
+  /// - Parameters:
+  ///   - coordinate: 날씨를 조회할 위치 좌표
+  ///   - units: 온도 단위 (섭씨: .celsius, 화씨: .fahrenheit)
+  /// - Returns: 현재 날씨 정보를 포함한 Single 스트림
   func getCurrentWeather(coordinate: Coordinate, units: TemperatureUnit) -> Single<CurrentWeather>
 }
 

--- a/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
+++ b/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
@@ -10,12 +10,12 @@ import RxSwift
 import CoreLocation
 
 protocol WeatherRepositoryType {
-  var temperatureUnit: TemperatureUnit { get set }
+  var units: TemperatureUnit { get set }
   func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather>
 }
 
 final class WeatherRepository: WeatherRepositoryType {
-  var temperatureUnit: TemperatureUnit = .celsius
+  var units: TemperatureUnit = .celsius
   
   private let weatherService: WeatherServiceType
   
@@ -24,6 +24,6 @@ final class WeatherRepository: WeatherRepositoryType {
   }
   
   func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather> {
-    return weatherService.getCurrentWeather(coordinate: coordinate, units: temperatureUnit)
+    return weatherService.getCurrentWeather(coordinate: coordinate, units: units)
   }
 }

--- a/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
+++ b/SajaWeather/SajaWeather/Data/Service/WeatherRepository.swift
@@ -1,0 +1,29 @@
+//
+//  WeatherRepository.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/11/25.
+//
+
+import Foundation
+import RxSwift
+import CoreLocation
+
+protocol WeatherRepositoryType {
+  var temperatureUnit: TemperatureUnit { get set }
+  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather>
+}
+
+final class WeatherRepository: WeatherRepositoryType {
+  var temperatureUnit: TemperatureUnit = .celsius
+  
+  private let weatherService: WeatherServiceType
+  
+  init(weatherService: WeatherServiceType) {
+    self.weatherService = weatherService
+  }
+  
+  func getCurrentWeather(coordinate: CLLocationCoordinate2D) -> Single<CurrentWeather> {
+    return weatherService.getCurrentWeather(coordinate: coordinate, units: temperatureUnit)
+  }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #17 

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- TemperatureUnit: metric/imperial 문자열 값 갖는 enum
- WeatherAPI: TemperatureUnit 받는 units 매개변수 추가
- WeatherService: getCurrentWeather 메서드에 units 매개변수 추가
- WeatherRepository: WeatherService를 감싸는 WeatherRepository
  - CLLocationCoordinate2D typealias 추가로 CoreLocation import 의존성 제거

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->
### Reactor에서 WeatherRepository 사용해 섭씨 화씨 요청하는 방법(참고용)
- 단지 사용방법을 위한 예시일 뿐입니다..! 자세한 것은 주석 확인해주세요!!!
- 아직 가져오는 서비스가 완전히 구현이 안되서 ㅎㅎㅎㅎ,,, 제대로 작동하는지에 대한 확인은 못했습니다,, 
 ```swift
 enum Action {
     case loadWeather(Coordinate, TemperatureUnit)
     case toggleTemperatureUnit
 }
 
 func mutate(action: Action) -> Observable<Mutation> {
     switch action {
     case .loadWeather(let coordinate, let units):
         return weatherRepository.getCurrentWeather(coordinate: coordinate, units: units)
             ...
     }
 }
 ```
<br>
