### PR TITLE
[chore] #26 searchViewReactor 수정 및 뷰컨트롤러 구현

### DIFF
--- a/SajaWeather/SajaWeather/App/Flow/AppFlow.swift
+++ b/SajaWeather/SajaWeather/App/Flow/AppFlow.swift
@@ -106,9 +106,9 @@ final class AppFlow: Flow {
   
   private func navigateToSearch() -> FlowContributors {
     // TODO: Search Reactor와 ViewController
-    /*
+
      // Search에 필요한 의존성 주입
-     let reactor = SearchReactor(
+     let reactor = SearchViewReactor(
      locationSearchService: locationSearchService
      )
      let viewController = SearchViewController(reactor: reactor)
@@ -120,15 +120,6 @@ final class AppFlow: Flow {
      withNextPresentable: viewController,
      withNextStepper: viewController
      ))
-     */
-    
-    // 임시 구현
-    let tempViewController = UIViewController()
-    tempViewController.view.backgroundColor = .systemGreen
-    tempViewController.modalPresentationStyle = .fullScreen
-    
-    rootViewController.present(tempViewController, animated: true)
-    return .none
   }
   
   private func dismissSearchAndUpdateWeather(coordinate: Coordinate?) -> FlowContributors {

--- a/SajaWeather/SajaWeather/Scene/Search/SearchViewController.swift
+++ b/SajaWeather/SajaWeather/Scene/Search/SearchViewController.swift
@@ -15,11 +15,11 @@ import Then
 final class SearchViewController: BaseViewController, View {
   
   private let backgroundView = UIView().then {
-    $0.backgroundColor = .white
+    $0.backgroundColor = .black
   }
   
   private let overlayView = UIView().then {
-    $0.backgroundColor = UIColor.gray.withAlphaComponent(0.25)
+    $0.backgroundColor = UIColor.gray.withAlphaComponent(0.7)
   }
   
   private let searchBar = UISearchBar().then {

--- a/SajaWeather/SajaWeather/Scene/Search/SearchViewController.swift
+++ b/SajaWeather/SajaWeather/Scene/Search/SearchViewController.swift
@@ -1,0 +1,286 @@
+//
+//  SearchViewController.swift
+//  SajaWeather
+//
+//  Created by Milou on 8/12/25.
+//
+
+import UIKit
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class SearchViewController: BaseViewController, View {
+  
+  private let backgroundView = UIView().then {
+    $0.backgroundColor = .white
+  }
+  
+  private let overlayView = UIView().then {
+    $0.backgroundColor = UIColor.gray.withAlphaComponent(0.25)
+  }
+  
+  private let searchBar = UISearchBar().then {
+    $0.placeholder = "지역 검색"
+    $0.searchBarStyle = .minimal
+    $0.backgroundColor = .clear
+    $0.tintColor = .white
+    
+    $0.searchTextField.leftView?.tintColor = .white
+    $0.searchTextField.borderStyle = .none
+    $0.searchTextField.backgroundColor = .clear
+    $0.searchTextField.layer.cornerRadius = 10
+    $0.searchTextField.layer.borderWidth = 2
+    $0.searchTextField.layer.borderColor = UIColor.white.cgColor
+    $0.searchTextField.textColor = .white
+    $0.searchTextField.font = .systemFont(ofSize: 16)
+    
+    $0.searchTextField.attributedPlaceholder = NSAttributedString(
+      string: "지역 검색",
+      attributes: [NSAttributedString.Key.foregroundColor: UIColor.white.withAlphaComponent(0.7)]
+    )
+  }
+  
+  private let recentSearchLabel = UILabel().then {
+    $0.text = "최근 검색"
+    $0.textColor = .lightGray
+    $0.font = .systemFont(ofSize: 12, weight: .medium)
+  }
+  
+  private let tableView = UITableView().then {
+    $0.backgroundColor = .clear
+    $0.separatorStyle = .none
+    $0.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+  }
+  
+  private let searchLionImageView = UIImageView().then {
+    $0.image = UIImage(named: "search_lion")
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  private let loadingIndicator = UIActivityIndicatorView(style: .medium).then {
+    $0.color = .white
+    $0.hidesWhenStopped = true
+  }
+  
+  init(reactor: SearchViewReactor) {
+    super.init(nibName: nil, bundle: nil)
+    self.reactor = reactor
+  }
+  
+  @MainActor required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupUI()
+    reactor?.action.onNext(.viewDidLoad)
+  }
+  
+  private func setupUI() {
+    view.addSubview(backgroundView)
+    view.addSubview(overlayView)
+    
+    backgroundView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    overlayView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    [searchBar, recentSearchLabel, tableView, searchLionImageView, loadingIndicator]
+      .forEach { overlayView.addSubview($0) }
+    
+    searchBar.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+      $0.height.equalTo(54)
+    }
+    
+    recentSearchLabel.snp.makeConstraints {
+      $0.top.equalTo(searchBar.snp.bottom).offset(16)
+      $0.leading.equalToSuperview().offset(20)
+    }
+    
+    tableView.snp.makeConstraints {
+      $0.top.equalTo(recentSearchLabel.snp.bottom)
+      $0.horizontalEdges.equalToSuperview()
+      $0.bottom.equalTo(view.safeAreaLayoutGuide)
+    }
+    
+    searchLionImageView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.width.equalTo(200)
+      $0.height.equalTo(200)
+    }
+    
+    loadingIndicator.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+  }
+  
+  func bind(reactor: SearchViewReactor) {
+    bindActions(reactor)
+    bindStates(reactor)
+  }
+  
+  private func bindActions(_ reactor: SearchViewReactor) {
+    // 검색바 포커스 시작
+    searchBar.rx.textDidBeginEditing
+      .map { Reactor.Action.searchBarDidBeginEditing }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    // 검색바 포커스 종료
+    searchBar.rx.textDidEndEditing
+      .map { Reactor.Action.searchBarDidEndEditing }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    searchBar.rx.cancelButtonClicked
+      .map { Reactor.Action.cancelButtonClicked }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    // 검색어 변경
+    searchBar.rx.text.orEmpty
+      .distinctUntilChanged()
+      .map { Reactor.Action.searchTextChanged($0) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    tableView.rx.itemSelected
+      .withLatestFrom(reactor.state) { indexPath, state in
+        let items: [Location] = {
+          switch state.displayState {
+          case .recentSearches:
+            return state.recentSearches
+          case .searchResults:
+            return state.searchResults
+          case .empty:
+            return []
+          }
+        }()
+        return (indexPath, state.displayState, items)
+      }
+      .bind { [weak self] indexPath, displayState, items in
+        self?.handleCellSelection(
+          at: indexPath,
+          displayState: displayState,
+          items: items,
+          reactor: reactor
+        )
+      }
+      .disposed(by: disposeBag)
+  }
+  
+  private func bindStates(_ reactor: SearchViewReactor) {
+    reactor.state.map(\.displayState)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .bind { [weak self] state in
+        self?.updateUI(for: state)
+      }
+      .disposed(by: disposeBag)
+    
+    reactor.state.map(\.isSearchBarFocused)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .bind { [weak self] isFocused in
+        self?.searchBar.showsCancelButton = isFocused
+        if !isFocused {
+          self?.searchBar.resignFirstResponder()
+        }
+      }
+      .disposed(by: disposeBag)
+    
+    reactor.state.map(\.searchText)
+      .distinctUntilChanged()
+      .observe(on: MainScheduler.instance)
+      .bind { [weak self] text in
+        if self?.searchBar.text != text {
+          self?.searchBar.text = text
+        }
+      }
+      .disposed(by: disposeBag)
+    
+    // 테이블뷰 데이터 바인딩
+    reactor.state.map { state -> [String] in
+      switch state.displayState {
+      case .recentSearches:
+        return state.recentSearches.map(\.fullAddress)
+      case .searchResults:
+        return state.searchResults.map(\.fullAddress)
+      case .empty:
+        return []
+      }
+    }
+    .bind(to: tableView.rx.items(cellIdentifier: "Cell")) { _, address, cell in
+      self.configureCell(cell, with: address)
+    }
+    .disposed(by: disposeBag)
+    
+    // 화면 전환 처리
+    reactor.state.map(\.selectedLocation)
+      .compactMap { $0 }
+      .map { AppStep.searchIsDismissed($0.coordinate) }
+      .bind(to: steps)
+      .disposed(by: disposeBag)
+  }
+  
+  private func updateUI(for displayState: SearchViewReactor.DisplayState) {
+    switch displayState {
+    case .empty:
+      recentSearchLabel.isHidden = true
+      tableView.isHidden = true
+      searchLionImageView.isHidden = false
+      
+    case .recentSearches:
+      recentSearchLabel.isHidden = false
+      tableView.isHidden = false
+      searchLionImageView.isHidden = true
+      
+    case .searchResults:
+      recentSearchLabel.isHidden = true
+      tableView.isHidden = false
+      searchLionImageView.isHidden = true
+    }
+  }
+  
+  private func configureCell(_ cell: UITableViewCell, with address: String) {
+    var content = cell.defaultContentConfiguration()
+    content.text = address
+    content.textProperties.color = .white
+    cell.contentConfiguration = content
+    cell.backgroundColor = .clear
+  }
+  
+  private func handleCellSelection(
+    at indexPath: IndexPath,
+    displayState: SearchViewReactor.DisplayState,
+    items: [Location],
+    reactor: SearchViewReactor
+  ) {
+    guard indexPath.row < items.count else { return }
+    
+    let selectedLocation = items[indexPath.row]
+    tableView.deselectRow(at: indexPath, animated: true)
+    
+    let action: SearchViewReactor.Action = {
+      switch displayState {
+      case .recentSearches:
+        return .selectRecentSearch(selectedLocation)
+      case .searchResults:
+        return .selectLocation(selectedLocation)
+      case .empty:
+        return .selectLocation(selectedLocation)
+      }
+    }()
+    
+    reactor.action.onNext(action)
+  }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [Feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #26

<br>

### 🦁 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

- AppFlow.swift: 임시 구현 실제 SearchViewController로 교체
- SearchViewController.swift: UISearchBar 기반 구현 (초기에는 UITextField 사용했다가 변경)
  - **검색 결과 사라지는 버그 아직 해결 못함**
- SearchViewReactor.swift: DisplayState enum으로 UI 상태 통합, 불필요한 것들 제거




<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->
<img  width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 03 02 30" src="https://github.com/user-attachments/assets/1969bd2b-5dea-4cdf-8c41-741128d6fbe4" />
<img  width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 03 02 36" src="https://github.com/user-attachments/assets/f96caa54-ffee-4f88-ba87-e4ff99b0ce10" />
<img  width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 03 02 41" src="https://github.com/user-attachments/assets/6608ac00-016a-4155-95ae-8e5eabb338e8" />

<br>
<br>

[기록용] 개발 과정에서 겪었던 어려움
1. UI 컴포넌트 선택의 혼란
- 문제: 처음에 UITextField + 커스텀 버튼으로 구현
- 해결: UISearchBar로 변경하여 네이티브 UX 활용 (취소 버튼 자동 처리)
2. 상태 관리 복잡성
- 문제: 너무 많은 computed property로 UI 상태 분산 관리
- 해결: DisplayState enum으로 통합하여 단순화
3. 초기 상태 표시 오류
- 문제: 앱 시작 시 최근 검색어가 바로 표시됨
- 해결: isSearchBarFocused 상태 추가로 포커스 시에만 최근 검색 표시
4. 취소 버튼 자동 생성 이슈
- 문제: UISearchBar 취소 버튼이 자동으로 생기지 않음
- 해결: showsCancelButton 속성을 포커스 상태에 따라 제어

